### PR TITLE
16272: Updated stitch vs-code extension to validate and auto-complete *.integration.yaml files and the preview window also now works with YAML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the "vscode-stitch" extension will be documented in this file.
 
+# 1.4.2
+- Added support for YAML integration.yaml files
+- Autocomplete when adding YAML files
+
 # 1.4.1
 - Added support for Multipart HTTP step
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the "vscode-stitch" extension will be documented in this file.
 
-# 1.4.2
+# 1.5.0
 - Added support for YAML integration.yaml files
 - Autocomplete when adding YAML files
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-stitch",
-	"version": "1.4.0",
+	"version": "1.4.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-stitch",
-			"version": "1.4.0",
+			"version": "1.4.1",
 			"dependencies": {
 				"axios": "^0.27.2",
 				"glob": "^7.2.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,7 @@
 			"version": "1.4.1",
 			"dependencies": {
 				"axios": "^0.27.2",
-				"glob": "^7.2.3",
-				"yaml": "2.2.2"
+				"glob": "^7.2.3"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.4",
@@ -4009,14 +4008,6 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
-		"node_modules/yaml": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
-			"engines": {
-				"node": ">= 14"
-			}
-		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -7101,11 +7092,6 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
-		},
-		"yaml": {
-			"version": "2.2.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
-			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "1.4.1",
 			"dependencies": {
 				"axios": "^0.27.2",
-				"glob": "^7.2.3"
+				"glob": "^7.2.3",
+				"yaml": "2.2.2"
 			},
 			"devDependencies": {
 				"@types/chai": "^4.3.4",
@@ -4008,6 +4009,14 @@
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
+		"node_modules/yaml": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA==",
+			"engines": {
+				"node": ">= 14"
+			}
+		},
 		"node_modules/yargs": {
 			"version": "16.2.0",
 			"resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -7092,6 +7101,11 @@
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
+		},
+		"yaml": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.2.2.tgz",
+			"integrity": "sha512-CBKFWExMn46Foo4cldiChEzn7S7SRV+wqiluAb6xmueD/fGyRHIhX8m14vVGgeFWjN540nKCNVj6P21eQjgTuA=="
 		},
 		"yargs": {
 			"version": "16.2.0",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,12 @@
 				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.metadata.schema.json"
 			}
 		],
+		"yamlValidation":[	
+			{
+				"fileMatch": "*.integration.yaml",
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.schema.json"
+			}
+		],
 		"viewsContainers": {
 			"activitybar": [
 				{

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"yamlValidation":[	
 			{
 				"fileMatch": "*.integration.yaml",
-				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.schema.json"
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
 			}
 		],
 		"viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
 		"yamlValidation":[	
 			{
 				"fileMatch": ["*.integration.yaml", "*.integration.yml"],
-				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.schema.json"
 			}
 		],
 		"viewsContainers": {

--- a/package.json
+++ b/package.json
@@ -157,7 +157,7 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.((json|yaml|yml))$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.(json|yaml|yml)$/"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
 				},
 				{
 					"command": "stitch.showTree",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/"
 				}
 			],
 			"editor/title": [
 				{
 					"command": "stitch.preview",
-					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/",
+					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/",
 					"group": "navigation"
 				}
 			],
@@ -138,7 +138,7 @@
 		"yamlValidation":[	
 			{
 				"fileMatch": "*.integration.yaml",
-				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.schema.json"
 			}
 		],
 		"viewsContainers": {
@@ -157,7 +157,7 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/"
 				}
 			]
 		},
@@ -201,7 +201,6 @@
 	},
 	"dependencies": {
 		"axios": "^0.27.2",
-		"glob": "^7.2.3",
-		"yaml": "2.2.2"
+		"glob": "^7.2.3"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"type": "git",
 		"url": "https://github.com/ShipitSmarter/vscode-stitch"
 	},
-	"version": "1.4.2",
+	"version": "1.5.0",
 	"engines": {
 		"vscode": "^1.75.1"
 	},

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
 				},
 				{
 					"command": "stitch.showTree",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json|yaml|yml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.(json|yaml|yml)$/"
 				}
 			],
 			"editor/title": [
 				{
 					"command": "stitch.preview",
-					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json|yaml|yml$/",
+					"when": "!stitch:previewActive && resourceFilename =~ /.integration.(json|yaml|yml)$/",
 					"group": "navigation"
 				}
 			],
@@ -157,7 +157,7 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.(json|yaml|yml)$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.((json|yaml|yml))$/"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
 				},
 				{
 					"command": "stitch.showTree",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
 				}
 			],
 			"editor/title": [
 				{
 					"command": "stitch.preview",
-					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/",
+					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/",
 					"group": "navigation"
 				}
 			],
@@ -138,7 +138,7 @@
 		"yamlValidation":[	
 			{
 				"fileMatch": "*.integration.yaml",
-				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/master/integration.schema.json"
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
 			}
 		],
 		"viewsContainers": {
@@ -157,7 +157,7 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
 				}
 			]
 		},
@@ -201,6 +201,7 @@
 	},
 	"dependencies": {
 		"axios": "^0.27.2",
-		"glob": "^7.2.3"
+		"glob": "^7.2.3",
+		"yaml": "2.2.2"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
 				},
 				{
 					"command": "stitch.showTree",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/"
 				}
 			],
 			"editor/title": [
 				{
 					"command": "stitch.preview",
-					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/",
+					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/",
 					"group": "navigation"
 				}
 			],
@@ -139,6 +139,10 @@
 			{
 				"fileMatch": "*.integration.yaml",
 				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
+			},
+			{
+				"fileMatch": "*.integration.yml",
+				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
 			}
 		],
 		"viewsContainers": {
@@ -157,7 +161,7 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/"
 				}
 			]
 		},

--- a/package.json
+++ b/package.json
@@ -179,6 +179,9 @@
 		"unittest": "npm run compile && mocha -u tdd ./out/test/suite/unitTests/**.test.js",
 		"deploy": "vsce publish"
 	},
+	"extensionDependencies": [
+		"redhat.vscode-yaml"
+	],
 	"devDependencies": {
 		"@types/chai": "^4.3.4",
 		"@types/chai-subset": "^1.3.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 		"type": "git",
 		"url": "https://github.com/ShipitSmarter/vscode-stitch"
 	},
-	"version": "1.4.1",
+	"version": "1.4.2",
 	"engines": {
 		"vscode": "^1.75.1"
 	},

--- a/package.json
+++ b/package.json
@@ -84,13 +84,13 @@
 				},
 				{
 					"command": "stitch.showTree",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json|yaml|yml$/"
 				}
 			],
 			"editor/title": [
 				{
 					"command": "stitch.preview",
-					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/",
+					"when": "!stitch:previewActive && resourceFilename =~ /.integration.json|yaml|yml$/",
 					"group": "navigation"
 				}
 			],
@@ -120,7 +120,7 @@
 				"stitch.rootFolderName": {
 					"type": "string",
 					"default": "files",
-					"description": "The name of the root folder where the *.integration.json files are stored",
+					"description": "The name of the root folder where the *.integration.json/yaml files are stored",
 					"pattern": "^[a-zA-Z0-9-]+$"
 				}
 			}
@@ -137,11 +137,7 @@
 		],
 		"yamlValidation":[	
 			{
-				"fileMatch": "*.integration.yaml",
-				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
-			},
-			{
-				"fileMatch": "*.integration.yml",
+				"fileMatch": ["*.integration.yaml", "*.integration.yml"],
 				"url": "https://raw.githubusercontent.com/ShipitSmarter/stitch-schemas/16330-camel-case-integration-schema/integration_camel.schema.json"
 			}
 		],
@@ -161,14 +157,14 @@
 					"name": "Stitch Model Tree",
 					"contextualTitle": "Stitch Model Tree",
 					"icon": "assets/icon.png",
-					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.json$/ || resourceFilename =~ /.integration.yaml$/ || resourceFilename =~ /.integration.yml$/"
+					"when": "stitch:contextAvailable || resourceFilename =~ /.integration.(json|yaml|yml)$/"
 				}
 			]
 		},
 		"viewsWelcome": [
 			{
 				"view": "stitch.modelTree",
-				"contents": "No *.integration.json file found\n\nPlease open an *.integration.json file to enable the model tree!"
+				"contents": "No *.integration.json/yaml file found\n\nPlease open an *.integration.json/yaml file to enable the model tree!"
 			}
 		]
 	},

--- a/src/StitchPreview.ts
+++ b/src/StitchPreview.ts
@@ -79,8 +79,8 @@ export class StitchPreview extends Disposable implements vscode.Disposable {
         const context = ContextHandler.getContext();
         if (!context) {
             this._handleStitchError({
-                title: `No ${CONSTANTS.integrationExtension} file found`,
-                description: `Please open an *${CONSTANTS.integrationExtension} file or directory to enable the preview!`
+                title: `No ${CONSTANTS.integrationExtensionJson} or ${CONSTANTS.integrationExtensionYaml} file found`,
+                description: `Please open an *${CONSTANTS.integrationExtensionJson} or *${CONSTANTS.integrationExtensionYaml} file or directory to enable the preview!`
             });
             return;
         }

--- a/src/StitchPreview.ts
+++ b/src/StitchPreview.ts
@@ -79,8 +79,8 @@ export class StitchPreview extends Disposable implements vscode.Disposable {
         const context = ContextHandler.getContext();
         if (!context) {
             this._handleStitchError({
-                title: `No ${CONSTANTS.integrationExtensionJson} or ${CONSTANTS.integrationExtensionYaml} file found`,
-                description: `Please open an *${CONSTANTS.integrationExtensionJson} or *${CONSTANTS.integrationExtensionYaml} file or directory to enable the preview!`
+                title: `No matching file found, supported files: ${CONSTANTS.integrationExtensions.join(', ')}`,
+                description: `Please open a valid file or directory to enable the preview! Valid files include: ${CONSTANTS.integrationExtensions.join(', ')}`
             });
             return;
         }

--- a/src/StitchPreview.ts
+++ b/src/StitchPreview.ts
@@ -79,8 +79,8 @@ export class StitchPreview extends Disposable implements vscode.Disposable {
         const context = ContextHandler.getContext();
         if (!context) {
             this._handleStitchError({
-                title: `No ${CONSTANTS.integrationExtensionJson} or ${CONSTANTS.integrationExtensionYaml} file found`,
-                description: `Please open an *${CONSTANTS.integrationExtensionJson} or *${CONSTANTS.integrationExtensionYaml} file or directory to enable the preview!`
+                title: `No ${CONSTANTS.integrationExtension} file found`,
+                description: `Please open an *${CONSTANTS.integrationExtension} file or directory to enable the preview!`
             });
             return;
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,6 @@
 export const CONSTANTS = {
-    integrationExtension: '.integration.json',
+    integrationExtensionJson: '.integration.json',
+    integrationExtensionYaml: '.integration.yaml',
     scenariosDirectoryName: 'scenarios',
     importsDirectoryName: 'imports',
     httpFileExtension: '.http',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 export const CONSTANTS = {
-    integrationExtensionJson: '.integration.json',
-    integrationExtensionYaml: '.integration.yaml',
+    integrationExtension: '.integration.json',
     scenariosDirectoryName: 'scenarios',
     importsDirectoryName: 'imports',
     httpFileExtension: '.http',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,5 @@
 export const CONSTANTS = {
-    integrationExtensionJson: '.integration.json',
-    integrationExtensionYaml: '.integration.yaml',
+    integrationExtensions: ['.integration.json', '.integration.yaml', '.integration.yml'],
     scenariosDirectoryName: 'scenarios',
     importsDirectoryName: 'imports',
     httpFileExtension: '.http',

--- a/src/utils/FileScrambler.ts
+++ b/src/utils/FileScrambler.ts
@@ -2,12 +2,10 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
-import * as YAML from 'yaml';
 import { ActiveFile, Context, ReadWorkspaceFileFunc } from '../types';
 import { CONSTANTS } from '../constants';
 import { ContextHandler } from '../ContextHandler';
 import { ScenarioHelper } from './ScenarioHelper';
-import { isJson } from "./helpers";
 
 export class FileScrambler {
     
@@ -31,17 +29,11 @@ export class FileScrambler {
         const integrationContent = FileScrambler.readFile(context, integrationPath);
         let integration: Integration;
         try {
-            if(isJson(integrationContent)){
-                integration = <Integration>JSON.parse(integrationContent);
-            }
-            else{
-                integration = <Integration>YAML.parse(integrationContent);
-            }
+            integration = <Integration>JSON.parse(integrationContent);
         }
         catch (e) {
-            throw new Error(`Integration file ${integrationPath} has invalid JSON/YAML`);     
+            throw new Error(`Integration file ${integrationPath} has invalid JSON`);
         }
-        
 
         return {
             content: integrationContent,
@@ -54,7 +46,7 @@ export class FileScrambler {
         const filepath = activeFile.filepath;
 
         // 1) Active file is the integration file
-        if (filepath.endsWith(CONSTANTS.integrationExtensionJson) || filepath.endsWith(CONSTANTS.integrationExtensionYaml)) {
+        if (filepath.endsWith(CONSTANTS.integrationExtension)) {
             return this._createContext(
                 activeFile,
                 filepath,
@@ -70,9 +62,7 @@ export class FileScrambler {
             folderToCheck = path.join(parentFolder, '../../');
         }
         
-        const integrationsJson = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionJson}`, undefined);
-        const integrationsYaml = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionYaml}`, undefined);
-        const integrations = integrationsJson.concat(integrationsYaml); 
+        const integrations = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtension}`, undefined);
         if (integrations && integrations.length > 0) {
             // filepath(vscode uri) => 'c:\\git\\Stitch\\vscode-stitch\\demo\\ups-booking\\scenarios\\0Simple\\step.ShipAccept.txt'
             // glob returns => 'c:/git/Stitch/vscode-stitch/demo/ups-booking/UPSShipping.integration.json'

--- a/src/utils/FileScrambler.ts
+++ b/src/utils/FileScrambler.ts
@@ -54,7 +54,7 @@ export class FileScrambler {
         const filepath = activeFile.filepath;
 
         // 1) Active file is the integration file
-        if (filepath.endsWith(CONSTANTS.integrationExtensionJson) || filepath.endsWith(CONSTANTS.integrationExtensionYaml)) {
+        if (CONSTANTS.integrationExtensions.some(e => filepath.endsWith(e))) {
             return this._createContext(
                 activeFile,
                 filepath,
@@ -69,10 +69,13 @@ export class FileScrambler {
         if (this._isScenarioFile(filepath)) {
             folderToCheck = path.join(parentFolder, '../../');
         }
+
+        let integrations: string[] = [];
+        for(let i =0; i < CONSTANTS.integrationExtensions.length; i++)
+        {
+            integrations = integrations.concat(glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensions[i]}`, undefined));
+        }
         
-        const integrationsJson = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionJson}`, undefined);
-        const integrationsYaml = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionYaml}`, undefined);
-        const integrations = integrationsJson.concat(integrationsYaml); 
         if (integrations && integrations.length > 0) {
             // filepath(vscode uri) => 'c:\\git\\Stitch\\vscode-stitch\\demo\\ups-booking\\scenarios\\0Simple\\step.ShipAccept.txt'
             // glob returns => 'c:/git/Stitch/vscode-stitch/demo/ups-booking/UPSShipping.integration.json'
@@ -105,6 +108,7 @@ export class FileScrambler {
 
         return;
     }
+
 
     private static _createContext(activeFile: ActiveFile, integrationFilePath: string, 
         integrationFilename: string, currentContext: Context | undefined

--- a/src/utils/FileScrambler.ts
+++ b/src/utils/FileScrambler.ts
@@ -2,10 +2,12 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as fs from 'fs';
 import * as glob from 'glob';
+import * as YAML from 'yaml';
 import { ActiveFile, Context, ReadWorkspaceFileFunc } from '../types';
 import { CONSTANTS } from '../constants';
 import { ContextHandler } from '../ContextHandler';
 import { ScenarioHelper } from './ScenarioHelper';
+import { isJson } from "./helpers";
 
 export class FileScrambler {
     
@@ -29,11 +31,17 @@ export class FileScrambler {
         const integrationContent = FileScrambler.readFile(context, integrationPath);
         let integration: Integration;
         try {
-            integration = <Integration>JSON.parse(integrationContent);
+            if(isJson(integrationContent)){
+                integration = <Integration>JSON.parse(integrationContent);
+            }
+            else{
+                integration = <Integration>YAML.parse(integrationContent);
+            }
         }
         catch (e) {
-            throw new Error(`Integration file ${integrationPath} has invalid JSON`);
+            throw new Error(`Integration file ${integrationPath} has invalid JSON/YAML`);     
         }
+        
 
         return {
             content: integrationContent,
@@ -46,7 +54,7 @@ export class FileScrambler {
         const filepath = activeFile.filepath;
 
         // 1) Active file is the integration file
-        if (filepath.endsWith(CONSTANTS.integrationExtension)) {
+        if (filepath.endsWith(CONSTANTS.integrationExtensionJson) || filepath.endsWith(CONSTANTS.integrationExtensionYaml)) {
             return this._createContext(
                 activeFile,
                 filepath,
@@ -62,7 +70,9 @@ export class FileScrambler {
             folderToCheck = path.join(parentFolder, '../../');
         }
         
-        const integrations = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtension}`, undefined);
+        const integrationsJson = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionJson}`, undefined);
+        const integrationsYaml = glob.sync(`${folderToCheck}/*${CONSTANTS.integrationExtensionYaml}`, undefined);
+        const integrations = integrationsJson.concat(integrationsYaml); 
         if (integrations && integrations.length > 0) {
             // filepath(vscode uri) => 'c:\\git\\Stitch\\vscode-stitch\\demo\\ups-booking\\scenarios\\0Simple\\step.ShipAccept.txt'
             // glob returns => 'c:/git/Stitch/vscode-stitch/demo/ups-booking/UPSShipping.integration.json'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -22,6 +22,11 @@ export function unescapeResponseBody(result: IntegrationResult): string {
     return unescapedBody;
 }
 
+export function isJson(content: string): boolean{
+    const jsonChars = ['{', '{'];
+    return jsonChars.some(c => content.startsWith(c));
+}
+
 export function findDirectoryWithinParent(currentFolder: string, folderNameToLookFor: string, maxUp: number) : string | undefined  {
     const pathCheck = path.join(currentFolder, folderNameToLookFor);
     if (maxUp === 0) { return undefined; }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -23,7 +23,7 @@ export function unescapeResponseBody(result: IntegrationResult): string {
 }
 
 export function isJson(content: string): boolean{
-    const jsonChars = ['{', '{'];
+    const jsonChars = ['{', '['];
     return jsonChars.some(c => content.startsWith(c));
 }
 

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -22,11 +22,6 @@ export function unescapeResponseBody(result: IntegrationResult): string {
     return unescapedBody;
 }
 
-export function isJson(content: string): boolean{
-    const jsonChars = ['{', '{'];
-    return jsonChars.some(c => content.startsWith(c));
-}
-
 export function findDirectoryWithinParent(currentFolder: string, folderNameToLookFor: string, maxUp: number) : string | undefined  {
     const pathCheck = path.join(currentFolder, folderNameToLookFor);
     if (maxUp === 0) { return undefined; }


### PR DESCRIPTION
This addresses work item 16272, it applies the existing *.integration.json schema to *.integration.yaml files.

Note: the contributes hook I used 'yamlValidation' is not supported natively by vscode. To use auto-complete in YAML files. Users will have to download the [YAML extension.](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml).

![16272](https://github.com/ShipitSmarter/vscode-stitch/assets/7061710/3fbe710f-4d30-4ee8-b518-eafd798ac3a7)
