### PR TITLE
18250 additional date time parse functions

### DIFF
--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -487,4 +487,196 @@ The XML escaped value
 #### Examples
 
 
+## `datetimelocal` functions
+Local date time functions are available through the object `datetimelocal` in Scriban. 
 
+-[ `datetimelocal.parse`](#datetimelocalparse)
+-[ `datetimelocal.parse_exact`](#datetimelocalparseexact)
+-[ `datetimelocal.to_string_default`](#datetimelocaltostringdefault)
+-[ `datetimelocal.to_string`](#datetimelocaltostring)
+
+[:top:](#additional-functions)
+
+### `datetimelocal.parse`
+
+```
+datetimelocal.parse <text>
+```
+
+#### Description
+Parse a local date time string to a local date time object
+
+#### Arguments
+- `text`: 
+  - The date time string to parse
+  - **Note:** will throw an `ArgumentException` if the given `text` contains time zone information.
+
+#### Returns
+The parsed local date time object
+
+#### Examples
+
+**1. Valid local date time string**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse("2021-01-01T00:00:00")
+    dt
+}}
+```
+
+> **output**
+```html
+01 Jan 2021 00:00:00
+```
+
+**2. Invalid date time string containing time zone offset**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse("2021-01-01T00:00:00Z")
+    dt
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Time zone specification is not allowed for local DateTime`
+
+[:top:](#additional-functions)
+
+
+### `datetimelocal.parse_exact`
+
+```
+datetimelocal.parse_exact <text> <format>
+```
+
+#### Description
+Parse a local date time string to a local date time object using the specified format
+
+#### Arguments
+- `text`: 
+  - The date time string to parse
+- `format`:
+  - A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+  - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
+
+#### Returns
+The parsed local date time object
+
+#### Examples
+
+**1. date time string in valid local date time format**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
+    dt
+}}
+```
+
+> **output**
+```html
+01 Jan 2021 00:00:00
+```
+
+**2. date time string in invalid format containing time zone offset**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
+    dt
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
+
+[:top:](#additional-functions)
+
+### `datetimelocal.to_string_default`
+
+```
+datetimelocal.to_string_default <datetime>
+```
+
+#### Description
+Convert a local date time object to an ISO 8601 compliant string using a default format
+
+#### Arguments
+- `datetime`: 
+  - The local date time object to convert
+
+#### Returns
+The ISO 8601 compliant string representation of the local date time object
+
+#### Examples
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse("2021-01-01T00:00:00")
+    str = datetimelocal.to_string_default(dt)
+    str
+}}
+```
+
+> **output**
+```html
+2021-01-01T00:00:00.000
+```
+
+[:top:](#additional-functions)
+
+### `datetimelocal.to_string`
+
+```
+datetimelocal.to_string <datetime> <format>
+```
+
+#### Description
+Convert a local date time object to a string using the specified format
+
+#### Arguments
+- `datetime`: 
+  - The local date time object to convert
+- `format`:
+    - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+    - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
+
+#### Returns
+The string representation of the local date time object
+
+#### Examples
+
+**1. Valid format**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse("2021-01-01T00:00:00")
+    str = datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
+    str
+}}
+```
+
+> **output**
+```html
+2021-01-01T00:00:00
+```
+
+**2. Invalid format containing time zone offset**
+> **input**
+```scriban-html
+{{
+    dt = datetimelocal.parse("2021-01-01T00:00:00")
+    str = datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
+    str
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
+
+[:top:](#additional-functions)

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -7,6 +7,8 @@ This document describes the various additional function available in scriban.
 - [`custom` functions](#custom-functions)
 - [`json` functions](#json-functions)
 - [`xml` functions](#xml-functions)
+- [`datetimelocal` functions](#datetimelocal-functions)
+- [`datetimeoffset` functions](#datetimeoffset-functions)
 
 [:top:](#additional-functions)
 
@@ -490,10 +492,9 @@ The XML escaped value
 ## `datetimelocal` functions
 Local date time functions are available through the object `datetimelocal` in Scriban. 
 
--[ `datetimelocal.parse`](#datetimelocalparse)
--[ `datetimelocal.parse_exact`](#datetimelocalparseexact)
--[ `datetimelocal.to_string_default`](#datetimelocaltostringdefault)
--[ `datetimelocal.to_string`](#datetimelocaltostring)
+- [ `datetimelocal.parse`](#datetimelocalparse)
+- [ `datetimelocal.parse_exact`](#datetimelocalparse_exact)
+- [ `datetimelocal.to_string`](#datetimelocalto_string)
 
 [:top:](#additional-functions)
 
@@ -520,8 +521,7 @@ The parsed local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse("2021-01-01T00:00:00")
-    dt
+    datetimelocal.parse("2021-01-01T00:00:00")
 }}
 ```
 
@@ -534,8 +534,7 @@ The parsed local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse("2021-01-01T00:00:00Z")
-    dt
+    datetimelocal.parse("2021-01-01T00:00:00Z")
 }}
 ```
 
@@ -571,8 +570,7 @@ The parsed local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
-    dt
+    datetimelocal.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
@@ -585,8 +583,7 @@ The parsed local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
-    dt
+    datetimelocal.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
@@ -596,47 +593,17 @@ throws `ArgumentException` : `Time zone specification in custom format is not al
 
 [:top:](#additional-functions)
 
-### `datetimelocal.to_string_default`
-
-```
-datetimelocal.to_string_default <datetime>
-```
-
-#### Description
-Convert a local date time object to an ISO 8601 compliant string using a default format
-
-#### Arguments
-- `datetime`: 
-  - The local date time object to convert
-
-#### Returns
-The ISO 8601 compliant string representation of the local date time object
-
-#### Examples
-> **input**
-```scriban-html
-{{
-    dt = datetimelocal.parse("2021-01-01T00:00:00")
-    str = datetimelocal.to_string_default(dt)
-    str
-}}
-```
-
-> **output**
-```html
-2021-01-01T00:00:00.000
-```
-
-[:top:](#additional-functions)
 
 ### `datetimelocal.to_string`
 
 ```
+datetimelocal.to_string <datetime>
 datetimelocal.to_string <datetime> <format>
 ```
 
 #### Description
-Convert a local date time object to a string using the specified format
+Convert a local date time object to a string, optionally using a specified format.
+If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:ss.fff` is used.
 
 #### Arguments
 - `datetime`: 
@@ -655,13 +622,15 @@ The string representation of the local date time object
 ```scriban-html
 {{
     dt = datetimelocal.parse("2021-01-01T00:00:00")
-    str = datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
-    str
+
+    datetimelocal.to_string(dt)
+    datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
 > **output**
 ```html
+2021-01-01T00:00:00.000
 2021-01-01T00:00:00
 ```
 
@@ -670,8 +639,7 @@ The string representation of the local date time object
 ```scriban-html
 {{
     dt = datetimelocal.parse("2021-01-01T00:00:00")
-    str = datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
-    str
+    datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
@@ -685,10 +653,9 @@ throws `ArgumentException` : `Time zone specification in custom format is not al
 
 Date time offset functions are available through the object `datetimeoffset` in Scriban.
 
--[ `datetimeoffset.parse`](#datetimeoffsetparse)
--[ `datetimeoffset.parse_exact`](#datetimeoffsetparseexact)
--[ `datetimeoffset.to_string_default`](#datetimeoffsettostringdefault)
--[ `datetimeoffset.to_string`](#datetimeoffsettostring)
+- [ `datetimeoffset.parse`](#datetimeoffsetparse)
+- [ `datetimeoffset.parse_exact`](#datetimeoffsetparse_exact)
+- [ `datetimeoffset.to_string`](#datetimeoffsetto_string)
 
 [:top:](#additional-functions)
 
@@ -715,8 +682,7 @@ The parsed date time offset object
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
-    dt
+    datetimeoffset.parse("2021-01-01T00:00:00Z")
 }}
 ```
 
@@ -729,8 +695,7 @@ The parsed date time offset object
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse("2021-01-01T00:00:00")
-    dt
+    datetimeoffset.parse("2021-01-01T00:00:00")
 }}
 ```
 
@@ -767,8 +732,7 @@ The parsed date time offset object
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
-    dt
+    datetimeoffset.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
@@ -781,50 +745,13 @@ The parsed date time offset object
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
-    dt
+    datetimeoffset.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
 > **output**
 
 throws `ArgumentException` : `Time zone specification in custom format is mandatory for DateTimeOffset`
-
-[:top:](#additional-functions)
-
-
-### `datetimeoffset.to_string_default`
-
-```
-datetimeoffset.to_string_default <datetimeoffset>
-```
-
-#### Description
-Convert a date time offset object to an ISO 8601 compliant string using a default format
-
-#### Arguments
-- `datetimeoffset`: 
-  - The date time offset object to convert
-  - **Note:** will throw an `ArgumentException` : `Argument must be of type DateTimeOffset` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
-
-#### Returns
-The ISO 8601 compliant string representation of the date time offset object
-
-#### Examples
-
-> **input**
-```scriban-html
-{{
-    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
-    str = datetimeoffset.to_string_default(dt)
-    str
-}}
-```
-
-> **output**
-```html
-2021-01-01T00:00:00.000+00:00
-```
 
 [:top:](#additional-functions)
 
@@ -836,7 +763,8 @@ datetimeoffset.to_string <datetimeoffset> <format>
 ```
 
 #### Description
-Convert a date time offset object to a string using the specified format
+Convert a date time offset object to a string, optionally using a specified format.
+If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:ss.fffK` is used.
 
 #### Arguments
 - `datetimeoffset`: 
@@ -851,22 +779,38 @@ The string representation of the date time offset object in the specified format
 
 #### Examples
 
+**1. Valid date time offset**
 > **input**
 ```scriban-html
 {{
     dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
-    str1 = datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
-    str2 = datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
-    str1
-    str2
+
+    datetimeoffset.to_string(dt)
+    datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
+    datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
 > **output**
 ```html
+2021-01-01T00:00:00+00:00
 2021-01-01T00:00:00
 2021-01-01T00:00:00+00:00
 ```
+
+**2. Invalid date time**
+> **input**
+```scriban-html
+{{
+    dt = date.parse("2021-01-01T00:00:00")
+
+    datetimeoffset.to_string(dt)
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Argument must be of type DateTimeOffset`
 
 [:top:](#additional-functions)
 

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -805,6 +805,7 @@ Convert a date time offset object to an ISO 8601 compliant string using a defaul
 #### Arguments
 - `datetimeoffset`: 
   - The date time offset object to convert
+  - **Note:** will throw an `ArgumentException` : `Argument must be of type DateTimeOffset` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
 
 #### Returns
 The ISO 8601 compliant string representation of the date time offset object
@@ -840,6 +841,7 @@ Convert a date time offset object to a string using the specified format
 #### Arguments
 - `datetimeoffset`: 
   - The date time offset object to convert
+  - **Note:** will throw an `ArgumentException` : `Argument must be of type DateTimeOffset` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
   - `format`:
     - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
     - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -746,9 +746,9 @@ If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:
 - `datetimeoffset`: 
   - The date time offset object to convert
   - **Note:** will throw an `ArgumentException` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
-  - `format`:
-    - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
-    - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.
+- `format`:
+  - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+  - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.
 
 #### Returns
 The string representation of the date time offset object in the specified format

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -493,7 +493,6 @@ The XML escaped value
 Local date time functions are available through the object `datetimelocal` in Scriban. 
 
 - [ `datetimelocal.parse`](#datetimelocalparse)
-- [ `datetimelocal.parse_exact`](#datetimelocalparse_exact)
 - [ `datetimelocal.to_string`](#datetimelocalto_string)
 
 [:top:](#additional-functions)
@@ -502,15 +501,19 @@ Local date time functions are available through the object `datetimelocal` in Sc
 
 ```
 datetimelocal.parse <text>
+datetimelocal.parse <text> <format>
 ```
 
 #### Description
-Parse a local date time string to a local date time object
+Parse a local date time string to a local date time object, optionally with a specified format
 
 #### Arguments
 - `text`: 
   - The date time string to parse
   - **Note:** will throw an `ArgumentException` if the given `text` contains time zone information.
+- `format`:
+  - (Optional) A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+  - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
 
 #### Returns
 The parsed local date time object
@@ -542,31 +545,8 @@ The parsed local date time object
 
 throws `ArgumentException` : `Time zone specification is not allowed for local DateTime`
 
-[:top:](#additional-functions)
 
-
-### `datetimelocal.parse_exact`
-
-```
-datetimelocal.parse_exact <text> <format>
-```
-
-#### Description
-Parse a local date time string to a local date time object using the specified format
-
-#### Arguments
-- `text`: 
-  - The date time string to parse
-- `format`:
-  - A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
-  - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
-
-#### Returns
-The parsed local date time object
-
-#### Examples
-
-**1. date time string in valid local date time format**
+**3. date time string with valid local date time format**
 > **input**
 ```scriban-html
 {{
@@ -579,7 +559,7 @@ The parsed local date time object
 01 Jan 2021 00:00:00
 ```
 
-**2. date time string in invalid format containing time zone offset**
+**4. date time string with invalid format containing time zone offset**
 > **input**
 ```scriban-html
 {{
@@ -608,6 +588,7 @@ If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:
 #### Arguments
 - `datetime`: 
   - The local date time object to convert
+  - **Note:** will throw an `ArgumentException` if a `DateTimeOffset` object is given (instead of a `DateTime` object)
 - `format`:
     - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
     - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
@@ -647,6 +628,20 @@ The string representation of the local date time object
 
 throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
 
+**3. Invalid date time**
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+
+    datetimelocal.to_string(dt)
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Unable to convert type 'DateTimeOffset' to 'DateTime'`
+
 [:top:](#additional-functions)
 
 ## `datetimeoffset` functions
@@ -654,7 +649,6 @@ throws `ArgumentException` : `Time zone specification in custom format is not al
 Date time offset functions are available through the object `datetimeoffset` in Scriban.
 
 - [ `datetimeoffset.parse`](#datetimeoffsetparse)
-- [ `datetimeoffset.parse_exact`](#datetimeoffsetparse_exact)
 - [ `datetimeoffset.to_string`](#datetimeoffsetto_string)
 
 [:top:](#additional-functions)
@@ -663,15 +657,19 @@ Date time offset functions are available through the object `datetimeoffset` in 
 
 ```
 datetimeoffset.parse <text>
+datetimeoffset.parse <text> <format>
 ```
 
 #### Description
-Parse a date time string to a date time offset object
+Parse a date time string to a date time offset object, optionally with a specified format
 
 #### Arguments
 - `text`: 
   - The date time string to parse
   - **Note:** will throw an `ArgumentException` if the given `text` does not contain time zone information.
+- `format`:
+  - (Optional) A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+  - **Note:** will throw an `ArgumentException` if the given `format` does not contain time zone information (i.e., `z` or `K` characters).
 
 #### Returns
 The parsed date time offset object
@@ -703,31 +701,8 @@ The parsed date time offset object
 
 throws `ArgumentException` : `Time zone specification is mandatory for DateTimeOffset`
 
-[:top:](#additional-functions)
 
-
-### `datetimeoffset.parse_exact`
-
-```
-datetimeoffset.parse_exact <text> <format>
-```
-
-#### Description
-Parse a date time string to a date time offset object using the specified format
-
-#### Arguments
-- `text`: 
-  - The date time string to parse
-- `format`:
-  - A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
-  - **Note:** will throw an `ArgumentException` if the given `format` does not contain time zone information (i.e., `z` or `K` characters).
-
-#### Returns
-The parsed date time offset object
-
-#### Examples
-
-**1. date time string in valid format**
+**3. date time string with valid format**
 
 > **input**
 ```scriban-html
@@ -741,7 +716,7 @@ The parsed date time offset object
 01 Jan 2021 00:00:00 +00:00
 ```
 
-**2. date time string in invalid format without time zone offset**
+**4. date time string with invalid format without time zone offset**
 > **input**
 ```scriban-html
 {{
@@ -759,6 +734,7 @@ throws `ArgumentException` : `Time zone specification in custom format is mandat
 ### `datetimeoffset.to_string`
 
 ```
+datetimeoffset.to_string <datetimeoffset>
 datetimeoffset.to_string <datetimeoffset> <format>
 ```
 
@@ -769,7 +745,7 @@ If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:
 #### Arguments
 - `datetimeoffset`: 
   - The date time offset object to convert
-  - **Note:** will throw an `ArgumentException` : `Argument must be of type DateTimeOffset` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
+  - **Note:** will throw an `ArgumentException` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
   - `format`:
     - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
     - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -778,7 +778,7 @@ The string representation of the absolute date time object in the specified form
 > **input**
 ```scriban-html
 {{
-    dt = date.parse("2021-01-01T00:00:00")
+    dt = datecalendar.parse("2021-01-01T00:00:00")
 
     dateabsolute.to_string(dt)
 }}

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -628,7 +628,7 @@ The string representation of the local date time object
 
 throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
 
-**3. Invalid date time**
+**3. Invalid date time offset**
 > **input**
 ```scriban-html
 {{

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -680,3 +680,192 @@ The string representation of the local date time object
 throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
 
 [:top:](#additional-functions)
+
+## `datetimeoffset` functions
+
+Date time offset functions are available through the object `datetimeoffset` in Scriban.
+
+-[ `datetimeoffset.parse`](#datetimeoffsetparse)
+-[ `datetimeoffset.parse_exact`](#datetimeoffsetparseexact)
+-[ `datetimeoffset.to_string_default`](#datetimeoffsettostringdefault)
+-[ `datetimeoffset.to_string`](#datetimeoffsettostring)
+
+[:top:](#additional-functions)
+
+### `datetimeoffset.parse`
+
+```
+datetimeoffset.parse <text>
+```
+
+#### Description
+Parse a date time string to a date time offset object
+
+#### Arguments
+- `text`: 
+  - The date time string to parse
+  - **Note:** will throw an `ArgumentException` if the given `text` does not contain time zone information.
+
+#### Returns
+The parsed date time offset object
+
+#### Examples
+
+**1. Valid date time string**
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+    dt
+}}
+```
+
+> **output**
+```html
+01 Jan 2021 00:00:00 +00:00
+```
+
+**2. Invalid date time string without time zone offset**
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse("2021-01-01T00:00:00")
+    dt
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Time zone specification is mandatory for DateTimeOffset`
+
+[:top:](#additional-functions)
+
+
+### `datetimeoffset.parse_exact`
+
+```
+datetimeoffset.parse_exact <text> <format>
+```
+
+#### Description
+Parse a date time string to a date time offset object using the specified format
+
+#### Arguments
+- `text`: 
+  - The date time string to parse
+- `format`:
+  - A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+  - **Note:** will throw an `ArgumentException` if the given `format` does not contain time zone information (i.e., `z` or `K` characters).
+
+#### Returns
+The parsed date time offset object
+
+#### Examples
+
+**1. date time string in valid format**
+
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
+    dt
+}}
+```
+
+> **output**
+```html
+01 Jan 2021 00:00:00 +00:00
+```
+
+**2. date time string in invalid format without time zone offset**
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
+    dt
+}}
+```
+
+> **output**
+
+throws `ArgumentException` : `Time zone specification in custom format is mandatory for DateTimeOffset`
+
+[:top:](#additional-functions)
+
+
+### `datetimeoffset.to_string_default`
+
+```
+datetimeoffset.to_string_default <datetimeoffset>
+```
+
+#### Description
+Convert a date time offset object to an ISO 8601 compliant string using a default format
+
+#### Arguments
+- `datetimeoffset`: 
+  - The date time offset object to convert
+
+#### Returns
+The ISO 8601 compliant string representation of the date time offset object
+
+#### Examples
+
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+    str = datetimeoffset.to_string_default(dt)
+    str
+}}
+```
+
+> **output**
+```html
+2021-01-01T00:00:00.000+00:00
+```
+
+[:top:](#additional-functions)
+
+
+### `datetimeoffset.to_string`
+
+```
+datetimeoffset.to_string <datetimeoffset> <format>
+```
+
+#### Description
+Convert a date time offset object to a string using the specified format
+
+#### Arguments
+- `datetimeoffset`: 
+  - The date time offset object to convert
+  - `format`:
+    - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
+    - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.
+
+#### Returns
+The string representation of the date time offset object in the specified format
+
+#### Examples
+
+> **input**
+```scriban-html
+{{
+    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+    str1 = datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
+    str2 = datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
+    str1
+    str2
+}}
+```
+
+> **output**
+```html
+2021-01-01T00:00:00
+2021-01-01T00:00:00+00:00
+```
+
+[:top:](#additional-functions)
+
+

--- a/docs/additional-functions.md
+++ b/docs/additional-functions.md
@@ -7,8 +7,8 @@ This document describes the various additional function available in scriban.
 - [`custom` functions](#custom-functions)
 - [`json` functions](#json-functions)
 - [`xml` functions](#xml-functions)
-- [`datetimelocal` functions](#datetimelocal-functions)
-- [`datetimeoffset` functions](#datetimeoffset-functions)
+- [`datecalendar` functions](#datecalendar-functions)
+- [`dateabsolute` functions](#dateabsolute-functions)
 
 [:top:](#additional-functions)
 
@@ -489,23 +489,23 @@ The XML escaped value
 #### Examples
 
 
-## `datetimelocal` functions
-Local date time functions are available through the object `datetimelocal` in Scriban. 
+## `datecalendar` functions
+Calendar date time functions are available through the object `datecalendar` in Scriban. 
 
-- [ `datetimelocal.parse`](#datetimelocalparse)
-- [ `datetimelocal.to_string`](#datetimelocalto_string)
+- [ `datecalendar.parse`](#datecalendarparse)
+- [ `datecalendar.to_string`](#datecalendarto_string)
 
 [:top:](#additional-functions)
 
-### `datetimelocal.parse`
+### `datecalendar.parse`
 
 ```
-datetimelocal.parse <text>
-datetimelocal.parse <text> <format>
+datecalendar.parse <text>
+datecalendar.parse <text> <format>
 ```
 
 #### Description
-Parse a local date time string to a local date time object, optionally with a specified format
+Parse a calendar date time string to a date time object without time zone offset, optionally with a specified format
 
 #### Arguments
 - `text`: 
@@ -516,15 +516,15 @@ Parse a local date time string to a local date time object, optionally with a sp
   - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
 
 #### Returns
-The parsed local date time object
+The parsed date time object
 
 #### Examples
 
-**1. Valid local date time string**
+**1. Valid calendar date time string**
 > **input**
 ```scriban-html
 {{
-    datetimelocal.parse("2021-01-01T00:00:00")
+    datecalendar.parse("2021-01-01T00:00:00")
 }}
 ```
 
@@ -537,20 +537,20 @@ The parsed local date time object
 > **input**
 ```scriban-html
 {{
-    datetimelocal.parse("2021-01-01T00:00:00Z")
+    datecalendar.parse("2021-01-01T00:00:00Z")
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Time zone specification is not allowed for local DateTime`
+throws `ArgumentException` : `Time zone specification is not allowed for calendar DateTime`
 
 
 **3. date time string with valid local date time format**
 > **input**
 ```scriban-html
 {{
-    datetimelocal.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
+    datecalendar.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
@@ -563,38 +563,38 @@ throws `ArgumentException` : `Time zone specification is not allowed for local D
 > **input**
 ```scriban-html
 {{
-    datetimelocal.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
+    datecalendar.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
+throws `ArgumentException` : `Time zone specification in custom format is not allowed for calendar DateTime`
 
 [:top:](#additional-functions)
 
 
-### `datetimelocal.to_string`
+### `datecalendar.to_string`
 
 ```
-datetimelocal.to_string <datetime>
-datetimelocal.to_string <datetime> <format>
+datecalendar.to_string <datetime>
+datecalendar.to_string <datetime> <format>
 ```
 
 #### Description
-Convert a local date time object to a string, optionally using a specified format.
+Convert a calendar date time object to a string, optionally using a specified format.
 If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:ss.fff` is used.
 
 #### Arguments
 - `datetime`: 
-  - The local date time object to convert
-  - **Note:** will throw an `ArgumentException` if a `DateTimeOffset` object is given (instead of a `DateTime` object)
+  - The calendar date time object to convert
+  - **Note:** will throw an `ArgumentException` if a `DateTimeOffset` object (i.e., an absolute date time) is given  instead of a `DateTime` object
 - `format`:
     - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
     - **Note:** will throw an `ArgumentException` if the given `format` contains time zone information (i.e., `z` or `K` characters).
 
 #### Returns
-The string representation of the local date time object
+The string representation of the calendar DateTime object
 
 #### Examples
 
@@ -602,10 +602,10 @@ The string representation of the local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse("2021-01-01T00:00:00")
+    dt = datecalendar.parse("2021-01-01T00:00:00")
 
-    datetimelocal.to_string(dt)
-    datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
+    datecalendar.to_string(dt)
+    datecalendar.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
@@ -619,22 +619,22 @@ The string representation of the local date time object
 > **input**
 ```scriban-html
 {{
-    dt = datetimelocal.parse("2021-01-01T00:00:00")
-    datetimelocal.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
+    dt = datecalendar.parse("2021-01-01T00:00:00")
+    datecalendar.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Time zone specification in custom format is not allowed for local DateTime`
+throws `ArgumentException` : `Time zone specification in custom format is not allowed for calendar DateTime`
 
-**3. Invalid date time offset**
+**3. Invalid absolute date time**
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+    dt = dateabsolute.parse("2021-01-01T00:00:00Z")
 
-    datetimelocal.to_string(dt)
+    datecalendar.to_string(dt)
 }}
 ```
 
@@ -644,43 +644,43 @@ throws `ArgumentException` : `Unable to convert type 'DateTimeOffset' to 'DateTi
 
 [:top:](#additional-functions)
 
-## `datetimeoffset` functions
+## `dateabsolute` functions
 
-Date time offset functions are available through the object `datetimeoffset` in Scriban.
+Absolute date time functions are available through the object `dateabsolute` in Scriban.
 
-- [ `datetimeoffset.parse`](#datetimeoffsetparse)
-- [ `datetimeoffset.to_string`](#datetimeoffsetto_string)
+- [ `dateabsolute.parse`](#dateabsoluteparse)
+- [ `dateabsolute.to_string`](#dateabsoluteto_string)
 
 [:top:](#additional-functions)
 
-### `datetimeoffset.parse`
+### `dateabsolute.parse`
 
 ```
-datetimeoffset.parse <text>
-datetimeoffset.parse <text> <format>
+dateabsolute.parse <text>
+dateabsolute.parse <text> <format>
 ```
 
 #### Description
-Parse a date time string to a date time offset object, optionally with a specified format
+Parse a date time string to an absolute date time object with time zone information, optionally with a specified format
 
 #### Arguments
 - `text`: 
-  - The date time string to parse
+  - The absolute date time string to parse
   - **Note:** will throw an `ArgumentException` if the given `text` does not contain time zone information.
 - `format`:
   - (Optional) A format specifier that defines the required format of text (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
   - **Note:** will throw an `ArgumentException` if the given `format` does not contain time zone information (i.e., `z` or `K` characters).
 
 #### Returns
-The parsed date time offset object
+The parsed absolute date time object
 
 #### Examples
 
-**1. Valid date time string**
+**1. Valid absolute date time string**
 > **input**
 ```scriban-html
 {{
-    datetimeoffset.parse("2021-01-01T00:00:00Z")
+    dateabsolute.parse("2021-01-01T00:00:00Z")
 }}
 ```
 
@@ -689,25 +689,25 @@ The parsed date time offset object
 01 Jan 2021 00:00:00 +00:00
 ```
 
-**2. Invalid date time string without time zone offset**
+**2. Invalid calendar date time string without time zone offset**
 > **input**
 ```scriban-html
 {{
-    datetimeoffset.parse("2021-01-01T00:00:00")
+    dateabsolute.parse("2021-01-01T00:00:00")
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Time zone specification is mandatory for DateTimeOffset`
+throws `ArgumentException` : `Time zone specification is mandatory for absolute DateTime`
 
 
-**3. date time string with valid format**
+**3. Date time string with valid custom format**
 
 > **input**
 ```scriban-html
 {{
-    datetimeoffset.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
+    dateabsolute.parse_exact("2021-01-01T00:00:00Z", "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
@@ -716,54 +716,54 @@ throws `ArgumentException` : `Time zone specification is mandatory for DateTimeO
 01 Jan 2021 00:00:00 +00:00
 ```
 
-**4. date time string with invalid format without time zone offset**
+**4. Date time string with invalid format without time zone offset**
 > **input**
 ```scriban-html
 {{
-    datetimeoffset.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
+    dateabsolute.parse_exact("2021-01-01T00:00:00", "yyyy-MM-ddTHH:mm:ss")
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Time zone specification in custom format is mandatory for DateTimeOffset`
+throws `ArgumentException` : `Time zone specification in custom format is mandatory for absolute DateTime`
 
 [:top:](#additional-functions)
 
 
-### `datetimeoffset.to_string`
+### `dateabsolute.to_string`
 
 ```
-datetimeoffset.to_string <datetimeoffset>
-datetimeoffset.to_string <datetimeoffset> <format>
+dateabsolute.to_string <datetime>
+dateabsolute.to_string <datetime> <format>
 ```
 
 #### Description
-Convert a date time offset object to a string, optionally using a specified format.
+Convert an absolute date time object to a string, optionally using a specified format.
 If no format is given, the default, ISO 8601 compliant format `yyyy-MM-ddTHH:mm:ss.fffK` is used.
 
 #### Arguments
-- `datetimeoffset`: 
-  - The date time offset object to convert
-  - **Note:** will throw an `ArgumentException` if the given argument is a `DateTime` object (instead of a `DateTimeOffset` object)
+- `datetime`: 
+  - The absolute date time object to convert
+  - **Note:** will throw an `ArgumentException` if the given argument is a calendar date time object (instead of an absolute date time object)
 - `format`:
   - A format specifier that defines the required format of the string (see [Microsoft's date time format specifications](https://learn.microsoft.com/en-us/dotnet/standard/base-types/custom-date-and-time-format-strings))
   - **Note:** it is NOT mandatory to specify a time zone offset in the given `format`.
 
 #### Returns
-The string representation of the date time offset object in the specified format
+The string representation of the absolute date time object in the specified format
 
 #### Examples
 
-**1. Valid date time offset**
+**1. Valid absolute date time**
 > **input**
 ```scriban-html
 {{
-    dt = datetimeoffset.parse("2021-01-01T00:00:00Z")
+    dt = dateabsolute.parse("2021-01-01T00:00:00Z")
 
-    datetimeoffset.to_string(dt)
-    datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
-    datetimeoffset.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
+    dateabsolute.to_string(dt)
+    dateabsolute.to_string(dt, "yyyy-MM-ddTHH:mm:ss")
+    dateabsolute.to_string(dt, "yyyy-MM-ddTHH:mm:ssK")
 }}
 ```
 
@@ -774,19 +774,19 @@ The string representation of the date time offset object in the specified format
 2021-01-01T00:00:00+00:00
 ```
 
-**2. Invalid date time**
+**2. Invalid calendar date time**
 > **input**
 ```scriban-html
 {{
     dt = date.parse("2021-01-01T00:00:00")
 
-    datetimeoffset.to_string(dt)
+    dateabsolute.to_string(dt)
 }}
 ```
 
 > **output**
 
-throws `ArgumentException` : `Argument must be of type DateTimeOffset`
+throws `ArgumentException` : `Argument must be of type DateTimeOffset, but was DateTime`
 
 [:top:](#additional-functions)
 


### PR DESCRIPTION
- adding documentation for new custom `datetimelocal` and `datetimeoffset` parsing and serialization functions

Related:
- PR in stitch (functional changes) : https://github.com/ShipitSmarter/stitch/pull/58
- PR in stitch-integrations (example integrations): https://github.com/ShipitSmarter/stitch-integrations/pull/218
- PR in vscode-stitch (documentation): https://github.com/ShipitSmarter/vscode-stitch/pull/47