### PR TITLE
feat: show functional error from editor response in case invalid format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to the "vscode-stitch" extension will be documented in this file.
 
+# 1.8.5
+- Show functional error message when invalid `json` or `xml` in HTTP step
+
 # 1.8.4
 - Allow `PrettyPrint` through settings
 

--- a/assets/style.css
+++ b/assets/style.css
@@ -9,6 +9,13 @@
 
 .action {
   border: 1px solid var(--vscode-editor-foreground);
+}
+
+.actionerror {
+  border: 1px solid var(--vscode-errorForeground);
+}
+
+.action .actionerror {
   border-radius: .15rem ;
   margin-bottom: .3rem;
   position: relative;
@@ -17,7 +24,7 @@
   word-break: break-word;
 }
 
-.action pre {
+.action pre, .actionerror pre {
   max-width: 100%;
   text-overflow: ellipsis;
   overflow: hidden;
@@ -27,13 +34,13 @@
   padding-top: .6em;
 }
 
-.action .type, .action .title {
+.action .type, .actionerror .type, .action .title, .actionerror .title {
   position: absolute;
   font-size: 1rem;
   padding: .15rem 0;
 }
 
-.action .title {
+.action .title, .actionerror .title {
   color: var(--vscode-editor-foreground);
   right: 1.5rem;
 }
@@ -48,7 +55,7 @@
   cursor: pointer;
 }
 
-.action .type {
+.action .type, .actionerror .type {
   top: -1px;
   left: -1px;
   background-color: var(--vscode-editor-foreground);
@@ -58,12 +65,16 @@
   line-height: 1.3rem;
 }
 
-.action .content {
+.action .content, .actionerror .content {
   margin-top: 2rem;
   padding: 0 .3rem;
 }
 
-.action .content .file-btn {
+.actionerror .content .errormessage {
+  color: var(--vscode-errorForeground);
+}
+
+.action .content .file-btn, .actionerror .content .file-btn {
   border: 1px solid var(--vscode-textPreformat-foreground);
   background-color: transparent;
   color: var(--vscode-textPreformat-foreground);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "vscode-stitch",
-	"version": "1.8.4",
+	"version": "1.8.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-stitch",
-			"version": "1.8.4",
+			"version": "1.8.5",
 			"dependencies": {
 				"axios": "^1.4.0",
 				"glob": "^7.2.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"type": "git",
 		"url": "https://github.com/ShipitSmarter/vscode-stitch"
 	},
-	"version": "1.8.4",
+	"version": "1.8.5",
 	"engines": {
 		"vscode": "^1.80.0"
 	},

--- a/src/StitchPreviewHtmlBuilder.ts
+++ b/src/StitchPreviewHtmlBuilder.ts
@@ -107,7 +107,7 @@ function _createStepHtml(step: StepResult, configuration: StepConfiguration) {
             return _createActionStepHtml('HTTP', configuration, 
                 configuration.$type === CONSTANTS.httpMultipartStepConfigurationType
                 ? _getHttpMultipartStepHtml(<HttpMulipartStepConfiguration>configuration) 
-                : _getHttpStepHtml(<HttpStepConfiguration>configuration));
+                : _getHttpStepHtml(<HttpStepConfiguration>configuration), (<HttpStepConfiguration>configuration).validFormat ? 'action' : 'actionerror');
         case CONSTANTS.renderTemplateStepResultType:
             return _createActionStepHtml('RenderTemplate', configuration, _getRenderTemplateStepHtml(<RenderTemplateStepResult>step, <RenderTemplateStepConfiguration>configuration));
         case CONSTANTS.mailStepResultType:
@@ -129,8 +129,8 @@ function _createStepHtml(step: StepResult, configuration: StepConfiguration) {
     }
 }
 
-function _createActionHtml(title: string, type: string, anchor: string, postMessageAction: string, body: string) {
-    return `<div class="action" id="${anchor}">
+function _createActionHtml(title: string, type: string, anchor: string, postMessageAction: string, body: string, cssClass: string = 'action') {
+    return `<div class="${cssClass}" id="${anchor}">
                 <span class="title">${title}</span>
                 <span class="type">${type}</span>
                 <svg xmlns="http://www.w3.org/2000/svg" 
@@ -146,7 +146,7 @@ function _createActionHtml(title: string, type: string, anchor: string, postMess
 }
 
 
-function _createActionStepHtml(title: string, step: StepConfiguration, body: string) {
+function _createActionStepHtml(title: string, step: StepConfiguration, body: string, cssClass:string = 'action') {
     let templateCode = StitchPreviewHtmlBuilder.escapeHtml(step.template);
     if (step.$type === CONSTANTS.httpMultipartStepConfigurationType) {
         templateCode = "Please use the 'Create HTTP request' button to view entire content";
@@ -159,7 +159,7 @@ function _createActionStepHtml(title: string, step: StepConfiguration, body: str
         `;
     }
 
-    return _createActionHtml(step.id, title, step.id, `{action: ${CommandAction.viewStepRequest}, content: '${step.id}' }`, actionHtmlBody);
+    return _createActionHtml(step.id, title, step.id, `{action: ${CommandAction.viewStepRequest}, content: '${step.id}' }`, actionHtmlBody, cssClass);
 }
 
 function _getDefaultStepHtml(step: BaseStepResult, configuration: StepConfiguration) {
@@ -180,8 +180,11 @@ function _getHttpStepHtml(configuration: HttpStepConfiguration) {
         html += `<p>${Object.keys(configuration.headers).map(key => `${key}:&nbsp;${configuration.headers?.[key]}<br />`).join('')}</p>`;
     }
     html += `<p>
-                Valid format:&nbsp;&nbsp;${configuration.validFormat}<br/>
-                Encoding name:&nbsp;${configuration.encodingName}
+                Valid format:&nbsp;&nbsp;${configuration.validFormat}<br/>`;
+    if (!configuration.validFormat) {
+        html += `Format error:&nbsp;&nbsp;<span class="errormessage">${configuration.formatErrorMessage}</span><br />`;
+    }
+    html +=`Encoding name:&nbsp;${configuration.encodingName}
             </p>`;
     html += `<button class="file-btn" onclick="vscode.postMessage({action: ${CommandAction.createHttpRequest}, content: '${configuration.id}' });">Create HTTP request</button>`;
 

--- a/src/StitchPreviewHtmlBuilder.ts
+++ b/src/StitchPreviewHtmlBuilder.ts
@@ -107,7 +107,7 @@ function _createStepHtml(step: StepResult, configuration: StepConfiguration) {
             return _createActionStepHtml('HTTP', configuration, 
                 configuration.$type === CONSTANTS.httpMultipartStepConfigurationType
                 ? _getHttpMultipartStepHtml(<HttpMulipartStepConfiguration>configuration) 
-                : _getHttpStepHtml(<HttpStepConfiguration>configuration), (<HttpStepConfiguration>configuration).validFormat ? 'action' : 'actionerror');
+                : _getHttpStepHtml(<HttpStepConfiguration>configuration), ((<HttpStepConfiguration>configuration).validFormat ?? true) ? 'action' : 'actionerror');
         case CONSTANTS.renderTemplateStepResultType:
             return _createActionStepHtml('RenderTemplate', configuration, _getRenderTemplateStepHtml(<RenderTemplateStepResult>step, <RenderTemplateStepConfiguration>configuration));
         case CONSTANTS.mailStepResultType:
@@ -181,7 +181,7 @@ function _getHttpStepHtml(configuration: HttpStepConfiguration) {
     }
     html += `<p>
                 Valid format:&nbsp;&nbsp;${configuration.validFormat}<br/>`;
-    if (!configuration.validFormat) {
+    if (configuration.validFormat === false) {
         html += `Format error:&nbsp;&nbsp;<span class="errormessage">${configuration.formatErrorMessage}</span><br />`;
     }
     html +=`Encoding name:&nbsp;${configuration.encodingName}

--- a/src/types/stepConfiguration.ts
+++ b/src/types/stepConfiguration.ts
@@ -14,6 +14,7 @@ export interface HttpStepConfiguration extends BaseStepConfiguration {
     url: string;
     headers?: Record<string, string>;
     validFormat: boolean | undefined;
+    formatErrorMessage : string;
 }
 
 export interface MailStepConfiguration extends BaseStepConfiguration {


### PR DESCRIPTION
- [json example](https://shipitsmarterbv-my.sharepoint.com/personal/bramvanderhorn_shipitsmarter_com/_layouts/15/onedrive.aspx?id=%2Fpersonal%2Fbramvanderhorn%5Fshipitsmarter%5Fcom%2FDocuments%2FChatbestanden%20van%20Microsoft%20Teams%2Fdetailed%2Dstitch%2Derror%2Egif&parent=%2Fpersonal%2Fbramvanderhorn%5Fshipitsmarter%5Fcom%2FDocuments%2FChatbestanden%20van%20Microsoft%20Teams&ga=1)
- [xml example](https://shipitsmarterbv-my.sharepoint.com/personal/bramvanderhorn_shipitsmarter_com/_layouts/15/onedrive.aspx?id=%2Fpersonal%2Fbramvanderhorn%5Fshipitsmarter%5Fcom%2FDocuments%2FChatbestanden%20van%20Microsoft%20Teams%2Fdetailed%2Dxml%2Derror%2Egif&parent=%2Fpersonal%2Fbramvanderhorn%5Fshipitsmarter%5Fcom%2FDocuments%2FChatbestanden%20van%20Microsoft%20Teams&ga=1)

see also [`stitch` pr](https://github.com/ShipitSmarter/stitch/pull/104)