### PR TITLE
feat: validate format and show functional error message for response

### DIFF
--- a/src/StitchPreviewHtmlBuilder.ts
+++ b/src/StitchPreviewHtmlBuilder.ts
@@ -83,17 +83,21 @@ function _createStepsHtml(response: EditorSimulateIntegrationResponse): string {
 
 function _createResponseHtml(response: EditorSimulateIntegrationResponse): string {
     const actionCommand = `{action: ${CommandAction.viewIntegrationResponse} }`;
-
-
-    let body = `<pre><code>${_getResponseBody(response.result)}</code></pre>`;
+    
+    let body = ``;
 
     if (response.result.headers) {
-        body = `<p>${Object.keys(response.result.headers).map(key => `${key}:&nbsp;${response.result.headers?.[key]}<br />`).join('')}</p>
-                ${body}`;
+        body += `<p>${Object.keys(response.result.headers).map(key => `${key}:&nbsp;${response.result.headers?.[key]}<br />`).join('')}</p>`;
     }
 
+    if (response.validFormat === false) {
+        body += `<p>Format error:&nbsp;&nbsp;<span class="errormessage">${response.formatErrorMessage}</span></p>`;
+    }
+
+    body += `<pre><code>${_getResponseBody(response.result)}</code></pre>`;
+
     return `<h2 id="integration_response">Response</h2>
-            ${_createActionHtml(`${response.result.statusCode}`, response.result.outputType, '', actionCommand, body)}`;
+            ${_createActionHtml(`${response.result.statusCode}`, response.result.outputType, '', actionCommand, body, (response.validFormat ?? true) ? 'action' : 'actionerror')}`;
 }
 
 function _createNavHtml(steps: Record<string, StepResult>): string {
@@ -179,11 +183,12 @@ function _getHttpStepHtml(configuration: HttpStepConfiguration) {
     if (configuration.headers) {
         html += `<p>${Object.keys(configuration.headers).map(key => `${key}:&nbsp;${configuration.headers?.[key]}<br />`).join('')}</p>`;
     }
-    html += `<p>
-                Valid format:&nbsp;&nbsp;${configuration.validFormat}<br/>`;
+    html += `<p>`;
+
     if (configuration.validFormat === false) {
         html += `Format error:&nbsp;&nbsp;<span class="errormessage">${configuration.formatErrorMessage}</span><br />`;
     }
+
     html +=`Encoding name:&nbsp;${configuration.encodingName}
             </p>`;
     html += `<button class="file-btn" onclick="vscode.postMessage({action: ${CommandAction.createHttpRequest}, content: '${configuration.id}' });">Create HTTP request</button>`;

--- a/src/types/apiTypes.ts
+++ b/src/types/apiTypes.ts
@@ -21,6 +21,8 @@ export interface StitchError {
 
 export interface EditorSimulateIntegrationResponse {
     result: IntegrationResult;
+    validFormat: boolean | undefined;
+    formatErrorMessage: string;
     stepConfigurations: Record<string, StepConfiguration>;
     integrationContext: IntegrationContext;
     treeModel: Record<string, unknown>;


### PR DESCRIPTION
See also:
- `stitch`: https://github.com/ShipitSmarter/stitch/pull/107
- `vscode-stitch`: https://github.com/ShipitSmarter/vscode-stitch/pull/55
- `sttich-integrations`: https://github.com/ShipitSmarter/stitch-integrations/pull/648

Example:
![image](https://github.com/ShipitSmarter/vscode-stitch/assets/9591412/bb566caa-770a-417d-99bb-5dc155af9aad)
